### PR TITLE
Add radar DNS record

### DIFF
--- a/config/birki.io.yaml
+++ b/config/birki.io.yaml
@@ -52,6 +52,16 @@ ingress:
         proxied: false
         auto-ttl: true
 
+# Stable DNS name for the private Radar endpoint. This intentionally points
+# directly at a Tailscale IP and must not be Cloudflare-proxied.
+radar:
+  - type: A
+    value: 100.75.116.66
+    octodns:
+      cloudflare:
+        proxied: false
+        auto-ttl: true
+
 # https://github.com/GrantBirki/journal
 journal:
   - type: CNAME

--- a/docs/radar.md
+++ b/docs/radar.md
@@ -1,0 +1,10 @@
+# Radar DNS
+
+`radar.birki.io` points directly at the Radar service's Tailscale IPv4 address.
+It is intentionally unproxied because Cloudflare cannot proxy traffic to
+Tailscale-only addresses.
+
+This record is a temporary stable service name while the native MagicDNS
+hostname is not reliable on every client. Revisit this workaround when MagicDNS
+for the endpoint resolves through both the system resolver and direct Quad100
+queries again.


### PR DESCRIPTION
## Summary

Adds an unproxied `radar.birki.io` A record that points directly at the Radar service's Tailscale IPv4 address.

This also adds a short note documenting why the record should stay unproxied and when the workaround can be revisited.