### PR TITLE
Add radar-core DNS record

### DIFF
--- a/config/birki.io.yaml
+++ b/config/birki.io.yaml
@@ -52,8 +52,18 @@ ingress:
         proxied: false
         auto-ttl: true
 
-# Stable DNS name for the private Radar endpoint. This intentionally points
+# Stable DNS names for the private Radar endpoint. These intentionally point
 # directly at a Tailscale IP and must not be Cloudflare-proxied.
+# radar-core is the operational OpenObserve/API/ingest endpoint.
+radar-core:
+  - type: A
+    value: 100.75.116.66
+    octodns:
+      cloudflare:
+        proxied: false
+        auto-ttl: true
+
+# radar is the authenticated read-only dashboard endpoint.
 radar:
   - type: A
     value: 100.75.116.66

--- a/docs/radar.md
+++ b/docs/radar.md
@@ -1,10 +1,8 @@
 # Radar DNS
 
-`radar.birki.io` points directly at the Radar service's Tailscale IPv4 address.
-It is intentionally unproxied because Cloudflare cannot proxy traffic to
-Tailscale-only addresses.
+`radar-core.birki.io` and `radar.birki.io` point directly at the Radar host's Tailscale IPv4 address. They are intentionally unproxied because Cloudflare cannot proxy traffic to Tailscale-only addresses.
 
-This record is a temporary stable service name while the native MagicDNS
-hostname is not reliable on every client. Revisit this workaround when MagicDNS
-for the endpoint resolves through both the system resolver and direct Quad100
-queries again.
+- `radar-core.birki.io`: operational Radar endpoint for OpenObserve, API access, and Vector ingest.
+- `radar.birki.io`: authenticated read-only Radar dashboard.
+
+These records are stable service names while native MagicDNS is not reliable on every client. Revisit this workaround when MagicDNS resolves through both the system resolver and direct Quad100 queries again.


### PR DESCRIPTION
## Summary

- add `radar-core.birki.io` as the operational Radar hostname
- keep `radar.birki.io` documented as the read-only dashboard hostname
- preserve both records as Tailscale-only, unproxied DNS entries