### PR TITLE
Add Fence audit mode to workflows

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -26,7 +26,7 @@ jobs:
       startsWith(github.event.comment.body, '.help') ||
       startsWith(github.event.comment.body, '.wcid') ||
       startsWith(github.event.comment.body, '.unlock')) }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: GrantBirki/fence@73584a435c4fbc54e7e60beeaddb078b350d6d68 # pin@v0.7.1

--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -26,9 +26,13 @@ jobs:
       startsWith(github.event.comment.body, '.help') ||
       startsWith(github.event.comment.body, '.wcid') ||
       startsWith(github.event.comment.body, '.unlock')) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
+      - uses: GrantBirki/fence@73584a435c4fbc54e7e60beeaddb078b350d6d68 # pin@v0.7.1
+        with:
+          mode: audit
+
       - name: branch-deploy
         id: branch-deploy
         uses: github/branch-deploy@fded0351b6b79f854b335c11b3d93063461dd288 # pin@v11

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,12 +10,16 @@ permissions:
 
 jobs:
   deployment-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs: # set outputs for use in downstream jobs
       continue: ${{ steps.deployment-check.outputs.continue }}
       sha: ${{ steps.deployment-check.outputs.sha }}
 
     steps:
+      - uses: GrantBirki/fence@73584a435c4fbc54e7e60beeaddb078b350d6d68 # pin@v0.7.1
+        with:
+          mode: audit
+
       # https://github.com/github/branch-deploy/blob/d3c24bd92505e623615b75ffdfac5ed5259adbdb/docs/merge-commit-strategy.md
       - name: deployment check
         uses: github/branch-deploy@fded0351b6b79f854b335c11b3d93063461dd288 # pin@v11
@@ -28,9 +32,13 @@ jobs:
     if: ${{ needs.deployment-check.outputs.continue == 'true' && github.event_name == 'push' }}
     needs: deployment-check
     environment: production
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
+      - uses: GrantBirki/fence@73584a435c4fbc54e7e60beeaddb078b350d6d68 # pin@v0.7.1
+        with:
+          mode: audit
+
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   deployment-check:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     outputs: # set outputs for use in downstream jobs
       continue: ${{ steps.deployment-check.outputs.continue }}
       sha: ${{ steps.deployment-check.outputs.sha }}
@@ -32,7 +32,7 @@ jobs:
     if: ${{ needs.deployment-check.outputs.continue == 'true' && github.event_name == 'push' }}
     needs: deployment-check
     environment: production
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: GrantBirki/fence@73584a435c4fbc54e7e60beeaddb078b350d6d68 # pin@v0.7.1

--- a/.github/workflows/json-yaml-validate.yml
+++ b/.github/workflows/json-yaml-validate.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   json-yaml-validate:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: GrantBirki/fence@73584a435c4fbc54e7e60beeaddb078b350d6d68 # pin@v0.7.1
         with:

--- a/.github/workflows/json-yaml-validate.yml
+++ b/.github/workflows/json-yaml-validate.yml
@@ -12,8 +12,12 @@ permissions:
 
 jobs:
   json-yaml-validate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
+      - uses: GrantBirki/fence@73584a435c4fbc54e7e60beeaddb078b350d6d68 # pin@v0.7.1
+        with:
+          mode: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
         with:
           persist-credentials: false

--- a/.github/workflows/new-pr.yml
+++ b/.github/workflows/new-pr.yml
@@ -12,9 +12,13 @@ permissions:
 jobs:
   new-pr:
     if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
+      - uses: GrantBirki/fence@73584a435c4fbc54e7e60beeaddb078b350d6d68 # pin@v0.7.1
+        with:
+          mode: audit
+
       # Comment on new PR requests with deployment instructions
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
         with:

--- a/.github/workflows/new-pr.yml
+++ b/.github/workflows/new-pr.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   new-pr:
     if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened' }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: GrantBirki/fence@73584a435c4fbc54e7e60beeaddb078b350d6d68 # pin@v0.7.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,13 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
+      - uses: GrantBirki/fence@73584a435c4fbc54e7e60beeaddb078b350d6d68 # pin@v0.7.1
+        with:
+          mode: audit
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
         with:
           persist-credentials: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: GrantBirki/fence@73584a435c4fbc54e7e60beeaddb078b350d6d68 # pin@v0.7.1

--- a/.github/workflows/unlock-on-merge.yml
+++ b/.github/workflows/unlock-on-merge.yml
@@ -9,10 +9,14 @@ permissions:
 
 jobs:
   unlock-on-merge:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event.pull_request.merged == true
 
     steps:
+      - uses: GrantBirki/fence@73584a435c4fbc54e7e60beeaddb078b350d6d68 # pin@v0.7.1
+        with:
+          mode: audit
+
       - name: unlock on merge
         uses: github/branch-deploy@fded0351b6b79f854b335c11b3d93063461dd288 # pin@v11
         id: unlock-on-merge

--- a/.github/workflows/unlock-on-merge.yml
+++ b/.github/workflows/unlock-on-merge.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   unlock-on-merge:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true
 
     steps:


### PR DESCRIPTION
## Summary
Add `GrantBirki/fence` in audit mode as the first step of every GitHub Actions job so the workflows can start collecting runner-hardening evidence without blocking traffic yet.

The action is pinned to the full `v0.7.1` distribution commit, and the workflows keep their current `ubuntu-latest` runner labels for now.
