### PR TITLE
Harden branch deploy checkouts

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -27,11 +27,38 @@ jobs:
       startsWith(github.event.comment.body, '.wcid') ||
       startsWith(github.event.comment.body, '.unlock')) }}
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ (startsWith(github.event.comment.body, '.deploy') || startsWith(github.event.comment.body, '.noop')) && 'dns-production' || format('branch-deploy-support-{0}', github.run_id) }}
+      cancel-in-progress: false
+      queue: max
 
     steps:
       - uses: GrantBirki/fence@73584a435c4fbc54e7e60beeaddb078b350d6d68 # pin@v0.7.1
         with:
           mode: audit
+
+      - name: derive trusted checkout path
+        id: trusted-path
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          echo "DEFAULT_BRANCH=${DEFAULT_BRANCH}"
+
+          trusted_dir="$(printf '%s' "${DEFAULT_BRANCH}" | sed -E 's/[^A-Za-z0-9._-]+/-/g; s/^-+//; s/-+$//')"
+
+          if [[ -z "${trusted_dir}" || "${trusted_dir}" == "." || "${trusted_dir}" == ".." ]]; then
+            echo "invalid trusted checkout directory derived from default branch: ${DEFAULT_BRANCH}" >&2
+            exit 1
+          fi
+
+          if [[ ! "${trusted_dir}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "trusted checkout directory contains unsafe characters: ${trusted_dir}" >&2
+            exit 1
+          fi
+
+          echo "trusted_dir=${trusted_dir}" >> "$GITHUB_OUTPUT"
+          echo "trusted checkout directory: ${trusted_dir}"
 
       - name: branch-deploy
         id: branch-deploy
@@ -43,26 +70,91 @@ jobs:
           production_environments: production
           sticky_locks: "true"
           admins: "GrantBirki"
+          deploy_message_path: ${{ steps.trusted-path.outputs.trusted_dir }}/.github/deployment_message.md
+          allow_forks: "false"
 
-      - name: checkout
+      - name: derive working checkout path
+        id: working-path
+        if: ${{ steps.branch-deploy.outputs.continue == 'true' }}
+        env:
+          DEPLOY_SHA: ${{ steps.branch-deploy.outputs.sha }}
+          TRUSTED_DIR: ${{ steps.trusted-path.outputs.trusted_dir }}
+        run: |
+          set -euo pipefail
+          echo "DEPLOY_SHA=${DEPLOY_SHA} - TRUSTED_DIR=${TRUSTED_DIR}"
+
+          if [[ ! "${DEPLOY_SHA}" =~ ^[0-9a-fA-F]{40}([0-9a-fA-F]{24})?$ ]]; then
+            echo "invalid branch-deploy sha output: ${DEPLOY_SHA}" >&2
+            exit 1
+          fi
+
+          working_dir="deployment-${DEPLOY_SHA}"
+
+          if [[ "${working_dir}" == "${TRUSTED_DIR}" ]]; then
+            echo "working checkout directory collides with trusted checkout directory: ${working_dir}" >&2
+            exit 1
+          fi
+
+          echo "working_dir=${working_dir}" >> "$GITHUB_OUTPUT"
+          echo "working checkout directory: ${working_dir}"
+
+      - name: checkout trusted
         if: ${{ steps.branch-deploy.outputs.continue == 'true' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
         with:
+          ref: ${{ github.sha }}
+          path: ${{ steps.trusted-path.outputs.trusted_dir }}
+          fetch-depth: 1
           persist-credentials: false
+
+      - name: checkout working deployment sha
+        if: ${{ steps.branch-deploy.outputs.continue == 'true' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
+        with:
           ref: ${{ steps.branch-deploy.outputs.sha }}
+          path: ${{ steps.working-path.outputs.working_dir }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: verify checkout provenance
+        if: ${{ steps.branch-deploy.outputs.continue == 'true' }}
+        env:
+          TRUSTED_DIR: ${{ steps.trusted-path.outputs.trusted_dir }}
+          TRUSTED_SHA: ${{ github.sha }}
+          WORKING_DIR: ${{ steps.working-path.outputs.working_dir }}
+          WORKING_SHA: ${{ steps.branch-deploy.outputs.sha }}
+        run: |
+          set -euo pipefail
+
+          trusted_head="$(git -C "${TRUSTED_DIR}" rev-parse HEAD)"
+          working_head="$(git -C "${WORKING_DIR}" rev-parse HEAD)"
+
+          if [[ "${trusted_head}" != "${TRUSTED_SHA}" ]]; then
+            echo "trusted checkout HEAD mismatch: expected ${TRUSTED_SHA}, got ${trusted_head}" >&2
+            exit 1
+          fi
+
+          if [[ "${working_head}" != "${WORKING_SHA}" ]]; then
+            echo "working checkout HEAD mismatch: expected ${WORKING_SHA}, got ${working_head}" >&2
+            exit 1
+          fi
+
+          echo "trusted checkout: ${TRUSTED_DIR}@${trusted_head}"
+          echo "working checkout: ${WORKING_DIR}@${working_head}"
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # pin@v6
         if: ${{ steps.branch-deploy.outputs.continue == 'true' }}
         with:
-          python-version-file: .python-version
+          python-version-file: ${{ steps.trusted-path.outputs.trusted_dir }}/.python-version
 
       - name: bootstrap
         if: ${{ steps.branch-deploy.outputs.continue == 'true' }}
+        working-directory: ${{ steps.trusted-path.outputs.trusted_dir }}
         run: script/bootstrap
 
       - name: setup venv
         if: ${{ steps.branch-deploy.outputs.continue == 'true' }}
-        run: echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
+        run: echo "${{ github.workspace }}/${{ steps.trusted-path.outputs.trusted_dir }}/.venv/bin" >> "$GITHUB_PATH"
 
       - name: force-check
         id: force-check
@@ -104,11 +196,12 @@ jobs:
         id: octodns
         if: ${{ steps.branch-deploy.outputs.continue == 'true' }}
         with:
-          config_path: production.yaml
+          config_path: ${{ steps.working-path.outputs.working_dir }}/production.yaml
           doit: ${{ steps.noop-check.outputs.doit }}
           force: ${{ steps.force-check.outputs.force }}
           poetry: false
         env:
+          OCTODNS_CONFIG_DIR: ${{ github.workspace }}/${{ steps.working-path.outputs.working_dir }}/config
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
 
@@ -121,6 +214,7 @@ jobs:
 
       - name: update deploy comment
         if: ${{ steps.branch-deploy.outputs.continue == 'true' }}
+        working-directory: ${{ steps.trusted-path.outputs.trusted_dir }}
         env:
           MSG: ${{ steps.octodns.outputs.plan }}
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,35 +33,123 @@ jobs:
     needs: deployment-check
     environment: production
     runs-on: ubuntu-latest
+    concurrency:
+      group: dns-production
+      cancel-in-progress: false
+      queue: max
 
     steps:
       - uses: GrantBirki/fence@73584a435c4fbc54e7e60beeaddb078b350d6d68 # pin@v0.7.1
         with:
           mode: audit
 
-      - name: checkout
+      - name: derive trusted checkout path
+        id: trusted-path
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          echo "DEFAULT_BRANCH=${DEFAULT_BRANCH}"
+
+          trusted_dir="$(printf '%s' "${DEFAULT_BRANCH}" | sed -E 's/[^A-Za-z0-9._-]+/-/g; s/^-+//; s/-+$//')"
+
+          if [[ -z "${trusted_dir}" || "${trusted_dir}" == "." || "${trusted_dir}" == ".." ]]; then
+            echo "invalid trusted checkout directory derived from default branch: ${DEFAULT_BRANCH}" >&2
+            exit 1
+          fi
+
+          if [[ ! "${trusted_dir}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "trusted checkout directory contains unsafe characters: ${trusted_dir}" >&2
+            exit 1
+          fi
+
+          echo "trusted_dir=${trusted_dir}" >> "$GITHUB_OUTPUT"
+          echo "trusted checkout directory: ${trusted_dir}"
+
+      - name: derive working checkout path
+        id: working-path
+        env:
+          DEPLOY_SHA: ${{ needs.deployment-check.outputs.sha }}
+          TRUSTED_DIR: ${{ steps.trusted-path.outputs.trusted_dir }}
+        run: |
+          set -euo pipefail
+          echo "DEPLOY_SHA=${DEPLOY_SHA} - TRUSTED_DIR=${TRUSTED_DIR}"
+
+          if [[ ! "${DEPLOY_SHA}" =~ ^[0-9a-fA-F]{40}([0-9a-fA-F]{24})?$ ]]; then
+            echo "invalid branch-deploy sha output: ${DEPLOY_SHA}" >&2
+            exit 1
+          fi
+
+          working_dir="deployment-${DEPLOY_SHA}"
+
+          if [[ "${working_dir}" == "${TRUSTED_DIR}" ]]; then
+            echo "working checkout directory collides with trusted checkout directory: ${working_dir}" >&2
+            exit 1
+          fi
+
+          echo "working_dir=${working_dir}" >> "$GITHUB_OUTPUT"
+          echo "working checkout directory: ${working_dir}"
+
+      - name: checkout trusted
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
         with:
+          ref: ${{ github.sha }}
+          path: ${{ steps.trusted-path.outputs.trusted_dir }}
+          fetch-depth: 1
           persist-credentials: false
+
+      - name: checkout working deployment sha
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
+        with:
           ref: ${{ needs.deployment-check.outputs.sha }}
+          path: ${{ steps.working-path.outputs.working_dir }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: verify checkout provenance
+        env:
+          TRUSTED_DIR: ${{ steps.trusted-path.outputs.trusted_dir }}
+          TRUSTED_SHA: ${{ github.sha }}
+          WORKING_DIR: ${{ steps.working-path.outputs.working_dir }}
+          WORKING_SHA: ${{ needs.deployment-check.outputs.sha }}
+        run: |
+          set -euo pipefail
+
+          trusted_head="$(git -C "${TRUSTED_DIR}" rev-parse HEAD)"
+          working_head="$(git -C "${WORKING_DIR}" rev-parse HEAD)"
+
+          if [[ "${trusted_head}" != "${TRUSTED_SHA}" ]]; then
+            echo "trusted checkout HEAD mismatch: expected ${TRUSTED_SHA}, got ${trusted_head}" >&2
+            exit 1
+          fi
+
+          if [[ "${working_head}" != "${WORKING_SHA}" ]]; then
+            echo "working checkout HEAD mismatch: expected ${WORKING_SHA}, got ${working_head}" >&2
+            exit 1
+          fi
+
+          echo "trusted checkout: ${TRUSTED_DIR}@${trusted_head}"
+          echo "working checkout: ${WORKING_DIR}@${working_head}"
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # pin@v6
         with:
-          python-version-file: .python-version
+          python-version-file: ${{ steps.trusted-path.outputs.trusted_dir }}/.python-version
 
       - name: bootstrap
+        working-directory: ${{ steps.trusted-path.outputs.trusted_dir }}
         run: script/bootstrap
 
       - name: setup venv
-        run: echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
+        run: echo "${{ github.workspace }}/${{ steps.trusted-path.outputs.trusted_dir }}/.venv/bin" >> "$GITHUB_PATH"
 
       - uses: grantbirki/octodns-action@21a241054238dfe984852b910ba7633bc1308b7d # pin@v1
         id: octodns
         with:
-          config_path: production.yaml
+          config_path: ${{ steps.working-path.outputs.working_dir }}/production.yaml
           doit: '--doit'
           poetry: false
         env:
+          OCTODNS_CONFIG_DIR: ${{ github.workspace }}/${{ steps.working-path.outputs.working_dir }}/config
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_TOKEN }}
 

--- a/production.yaml
+++ b/production.yaml
@@ -2,7 +2,7 @@
 providers:
   config:
     class: octodns.provider.yaml.YamlProvider
-    directory: ./config
+    directory: env/OCTODNS_CONFIG_DIR/./config
     default_ttl: 3600
     enforce_order: false
 

--- a/script/ci/test_update_deploy_msg.py
+++ b/script/ci/test_update_deploy_msg.py
@@ -23,6 +23,19 @@ class RenderDeployMessageTest(unittest.TestCase):
         self.assertIn('{{ ref }}', rendered)
         self.assertIn('{{ environment }}', rendered)
 
+    def test_escapes_nunjucks_opening_delimiters_in_results(self):
+        rendered = render_deploy_message(
+            '[[ results ]]',
+            '{{ value }}\n{% if changed %}\n{# note #}',
+        )
+
+        self.assertIn('{ { value }}', rendered)
+        self.assertIn('{ % if changed %}', rendered)
+        self.assertIn('{ # note #}', rendered)
+        self.assertNotIn('{{ value }}', rendered)
+        self.assertNotIn('{% if changed %}', rendered)
+        self.assertNotIn('{# note #}', rendered)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/script/ci/update_deploy_msg.py
+++ b/script/ci/update_deploy_msg.py
@@ -7,12 +7,25 @@ RAW_END = '{% endraw %}'
 RESULTS_PLACEHOLDER = '[[ results ]]'
 
 
+def escape_nunjucks_opening_delimiters(results):
+    escaped = []
+    results = str(results)
+
+    for index, char in enumerate(results):
+        if char == '{' and index + 1 < len(results) and results[index + 1] in '{%#':
+            escaped.append('{ ')
+        else:
+            escaped.append(char)
+
+    return ''.join(escaped)
+
+
 def render_deploy_message(template_text, results):
     return (
         template_text
         .replace(RAW_START, '')
         .replace(RAW_END, '')
-        .replace(RESULTS_PLACEHOLDER, str(results))
+        .replace(RESULTS_PLACEHOLDER, escape_nunjucks_opening_delimiters(results))
     )
 
 


### PR DESCRIPTION
## Summary

This PR hardens DNS branch-deploy workflows with separate trusted and working checkouts. Trusted default-branch code now supplies bootstrap/runtime and deployment message rendering, while the branch-deploy SHA supplies `production.yaml` and DNS records for `.noop`/`.deploy`.

It also serializes production DNS operations with a shared `dns-production` queue and escapes octoDNS output before it is inserted into the branch-deploy message template.
