### PR TITLE
Use OpenAI Fence v0.8.4

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -33,7 +33,7 @@ jobs:
       queue: max
 
     steps:
-      - uses: GrantBirki/fence@73584a435c4fbc54e7e60beeaddb078b350d6d68 # pin@v0.7.1
+      - uses: openai/fence@bbe8d131a54284a78390dbc2ce06893019830913 # pin@v0.8.4
         with:
           mode: audit
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
       sha: ${{ steps.deployment-check.outputs.sha }}
 
     steps:
-      - uses: GrantBirki/fence@73584a435c4fbc54e7e60beeaddb078b350d6d68 # pin@v0.7.1
+      - uses: openai/fence@bbe8d131a54284a78390dbc2ce06893019830913 # pin@v0.8.4
         with:
           mode: audit
 
@@ -39,7 +39,7 @@ jobs:
       queue: max
 
     steps:
-      - uses: GrantBirki/fence@73584a435c4fbc54e7e60beeaddb078b350d6d68 # pin@v0.7.1
+      - uses: openai/fence@bbe8d131a54284a78390dbc2ce06893019830913 # pin@v0.8.4
         with:
           mode: audit
 

--- a/.github/workflows/json-yaml-validate.yml
+++ b/.github/workflows/json-yaml-validate.yml
@@ -14,7 +14,7 @@ jobs:
   json-yaml-validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: GrantBirki/fence@73584a435c4fbc54e7e60beeaddb078b350d6d68 # pin@v0.7.1
+      - uses: openai/fence@bbe8d131a54284a78390dbc2ce06893019830913 # pin@v0.8.4
         with:
           mode: audit
 

--- a/.github/workflows/new-pr.yml
+++ b/.github/workflows/new-pr.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: GrantBirki/fence@73584a435c4fbc54e7e60beeaddb078b350d6d68 # pin@v0.7.1
+      - uses: openai/fence@bbe8d131a54284a78390dbc2ce06893019830913 # pin@v0.8.4
         with:
           mode: audit
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: GrantBirki/fence@73584a435c4fbc54e7e60beeaddb078b350d6d68 # pin@v0.7.1
+      - uses: openai/fence@bbe8d131a54284a78390dbc2ce06893019830913 # pin@v0.8.4
         with:
           mode: audit
 

--- a/.github/workflows/unlock-on-merge.yml
+++ b/.github/workflows/unlock-on-merge.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event.pull_request.merged == true
 
     steps:
-      - uses: GrantBirki/fence@73584a435c4fbc54e7e60beeaddb078b350d6d68 # pin@v0.7.1
+      - uses: openai/fence@bbe8d131a54284a78390dbc2ce06893019830913 # pin@v0.8.4
         with:
           mode: audit
 


### PR DESCRIPTION
## Summary

Switch all workflows from `GrantBirki/fence` to the full-SHA-pinned `openai/fence` v0.8.4 release. Preserve the existing Fence modes and configuration unchanged.
