### PR TITLE
Upgrade Fence to v0.8.7 in audit mode

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -26,14 +26,14 @@ jobs:
       startsWith(github.event.comment.body, '.help') ||
       startsWith(github.event.comment.body, '.wcid') ||
       startsWith(github.event.comment.body, '.unlock')) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ (startsWith(github.event.comment.body, '.deploy') || startsWith(github.event.comment.body, '.noop')) && 'dns-production' || format('branch-deploy-support-{0}', github.run_id) }}
       cancel-in-progress: false
       queue: max
 
     steps:
-      - uses: openai/fence@bbe8d131a54284a78390dbc2ce06893019830913 # pin@v0.8.4
+      - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
         with:
           mode: audit
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,13 +10,13 @@ permissions:
 
 jobs:
   deployment-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs: # set outputs for use in downstream jobs
       continue: ${{ steps.deployment-check.outputs.continue }}
       sha: ${{ steps.deployment-check.outputs.sha }}
 
     steps:
-      - uses: openai/fence@bbe8d131a54284a78390dbc2ce06893019830913 # pin@v0.8.4
+      - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
         with:
           mode: audit
 
@@ -32,14 +32,14 @@ jobs:
     if: ${{ needs.deployment-check.outputs.continue == 'true' && github.event_name == 'push' }}
     needs: deployment-check
     environment: production
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     concurrency:
       group: dns-production
       cancel-in-progress: false
       queue: max
 
     steps:
-      - uses: openai/fence@bbe8d131a54284a78390dbc2ce06893019830913 # pin@v0.8.4
+      - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
         with:
           mode: audit
 

--- a/.github/workflows/json-yaml-validate.yml
+++ b/.github/workflows/json-yaml-validate.yml
@@ -12,9 +12,9 @@ permissions:
 
 jobs:
   json-yaml-validate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: openai/fence@bbe8d131a54284a78390dbc2ce06893019830913 # pin@v0.8.4
+      - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
         with:
           mode: audit
 

--- a/.github/workflows/new-pr.yml
+++ b/.github/workflows/new-pr.yml
@@ -12,10 +12,10 @@ permissions:
 jobs:
   new-pr:
     if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
-      - uses: openai/fence@bbe8d131a54284a78390dbc2ce06893019830913 # pin@v0.8.4
+      - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
         with:
           mode: audit
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
-      - uses: openai/fence@bbe8d131a54284a78390dbc2ce06893019830913 # pin@v0.8.4
+      - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
         with:
           mode: audit
 

--- a/.github/workflows/unlock-on-merge.yml
+++ b/.github/workflows/unlock-on-merge.yml
@@ -9,11 +9,11 @@ permissions:
 
 jobs:
   unlock-on-merge:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event.pull_request.merged == true
 
     steps:
-      - uses: openai/fence@bbe8d131a54284a78390dbc2ce06893019830913 # pin@v0.8.4
+      - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
         with:
           mode: audit
 


### PR DESCRIPTION
Pins every GitHub-hosted Linux job to Ubuntu 24.04 and upgrades Fence to the immutable v0.8.7 commit. This keeps the existing audit posture so default-branch and branch-deploy evidence can be reviewed before enforcement.