### PR TITLE
Validate Fence enforcement rollout

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -35,7 +35,10 @@ jobs:
     steps:
       - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
         with:
-          mode: audit
+          allowlist: |
+            hostname pypi.org tcp 443
+            hostname files.pythonhosted.org tcp 443
+            hostname api.cloudflare.com tcp 443
 
       - name: derive trusted checkout path
         id: trusted-path

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,8 +17,6 @@ jobs:
 
     steps:
       - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
-        with:
-          mode: audit
 
       # https://github.com/github/branch-deploy/blob/d3c24bd92505e623615b75ffdfac5ed5259adbdb/docs/merge-commit-strategy.md
       - name: deployment check
@@ -41,7 +39,10 @@ jobs:
     steps:
       - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
         with:
-          mode: audit
+          allowlist: |
+            hostname pypi.org tcp 443
+            hostname files.pythonhosted.org tcp 443
+            hostname api.cloudflare.com tcp 443
 
       - name: derive trusted checkout path
         id: trusted-path

--- a/.github/workflows/json-yaml-validate.yml
+++ b/.github/workflows/json-yaml-validate.yml
@@ -15,8 +15,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
-        with:
-          mode: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
         with:

--- a/.github/workflows/new-pr.yml
+++ b/.github/workflows/new-pr.yml
@@ -16,8 +16,6 @@ jobs:
 
     steps:
       - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
-        with:
-          mode: audit
 
       # Comment on new PR requests with deployment instructions
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,9 @@ jobs:
     steps:
       - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
         with:
-          mode: audit
+          allowlist: |
+            hostname pypi.org tcp 443
+            hostname files.pythonhosted.org tcp 443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
         with:

--- a/.github/workflows/unlock-on-merge.yml
+++ b/.github/workflows/unlock-on-merge.yml
@@ -14,8 +14,6 @@ jobs:
 
     steps:
       - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
-        with:
-          mode: audit
 
       - name: unlock on merge
         uses: github/branch-deploy@fded0351b6b79f854b335c11b3d93063461dd288 # pin@v11


### PR DESCRIPTION
Moves all seven fenced Ubuntu jobs from audit to blocking mode after reviewing their audit summaries. The Python and OctoDNS jobs receive only the observed PyPI endpoints, while deployment paths also receive the exact Cloudflare API endpoint; GitHub compatibility remains at Fence defaults.