### PR TITLE
Restore ubuntu-latest runners

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -26,7 +26,7 @@ jobs:
       startsWith(github.event.comment.body, '.help') ||
       startsWith(github.event.comment.body, '.wcid') ||
       startsWith(github.event.comment.body, '.unlock')) }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     concurrency:
       group: ${{ (startsWith(github.event.comment.body, '.deploy') || startsWith(github.event.comment.body, '.noop')) && 'dns-production' || format('branch-deploy-support-{0}', github.run_id) }}
       cancel-in-progress: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   deployment-check:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     outputs: # set outputs for use in downstream jobs
       continue: ${{ steps.deployment-check.outputs.continue }}
       sha: ${{ steps.deployment-check.outputs.sha }}
@@ -30,7 +30,7 @@ jobs:
     if: ${{ needs.deployment-check.outputs.continue == 'true' && github.event_name == 'push' }}
     needs: deployment-check
     environment: production
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     concurrency:
       group: dns-production
       cancel-in-progress: false

--- a/.github/workflows/json-yaml-validate.yml
+++ b/.github/workflows/json-yaml-validate.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   json-yaml-validate:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
 

--- a/.github/workflows/new-pr.yml
+++ b/.github/workflows/new-pr.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   new-pr:
     if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened' }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7

--- a/.github/workflows/unlock-on-merge.yml
+++ b/.github/workflows/unlock-on-merge.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   unlock-on-merge:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true
 
     steps:


### PR DESCRIPTION
Restores the Fence-covered Linux jobs from the explicit `ubuntu-24.04` label to `ubuntu-latest`. Fence pins, modes, allowlists, permissions, and job structure remain unchanged; matching workflow assertions are updated where present.