### PR TITLE
Upgrade Branch Deploy to v12.0.0

### DIFF
--- a/.github/deployment_message.md
+++ b/.github/deployment_message.md
@@ -1,13 +1,13 @@
 ### Deployment Results {{ ":white_check_mark:" if status === "success" else ":x:" }}
 
-{% raw %}{% if status === "success" %} **{{ actor }}** successfully **{{ "noop" if noop else "branch" }}** deployed branch `{{ ref }}` to **{{ environment }}**{% endif %}
+{% if status === "success" %} **{{ actor }}** successfully **{{ "noop" if noop else "branch" }}** deployed branch `{{ ref }}` to **{{ environment }}**{% endif %}
 
 {% if status === "failure" %} **{{ actor }}** your **{{ "noop" if noop else "branch" }}** deployment of `{{ ref }}` failed to deploy to the **{{ environment }}** environment{% endif %}
 
-{% if status === "unknown" %} **{{ actor }}** your **{{ "noop" if noop else "branch" }}** deployment of `{{ ref }}` is in an unknown state when trying to deploy to the **{{ environment }}** environment.{% endif %}{% endraw %}
+{% if status === "unknown" %} **{{ actor }}** your **{{ "noop" if noop else "branch" }}** deployment of `{{ ref }}` is in an unknown state when trying to deploy to the **{{ environment }}** environment.{% endif %}
 
 <details><summary>Show Results</summary>
 
-[[ results ]]
+{{ results }}
 
 </details>

--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: branch-deploy
         id: branch-deploy
-        uses: github/branch-deploy@fded0351b6b79f854b335c11b3d93063461dd288 # pin@v11
+        uses: github/branch-deploy@f0984057ffe1aa340aa017b6eafb894310aed88e # pin@v12.0.0
         with:
           trigger: ".deploy"
           environment: production
@@ -73,7 +73,7 @@ jobs:
           production_environments: production
           sticky_locks: "true"
           admins: "GrantBirki"
-          deploy_message_path: ${{ steps.trusted-path.outputs.trusted_dir }}/.github/deployment_message.md
+          deploy_message_path: .github/deployment_message.md
           allow_forks: "false"
 
       - name: derive working checkout path

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
 
       # https://github.com/github/branch-deploy/blob/d3c24bd92505e623615b75ffdfac5ed5259adbdb/docs/merge-commit-strategy.md
       - name: deployment check
-        uses: github/branch-deploy@fded0351b6b79f854b335c11b3d93063461dd288 # pin@v11
+        uses: github/branch-deploy@f0984057ffe1aa340aa017b6eafb894310aed88e # pin@v12.0.0
         id: deployment-check
         with:
           merge_deploy_mode: "true"

--- a/.github/workflows/unlock-on-merge.yml
+++ b/.github/workflows/unlock-on-merge.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: openai/fence@c22db5d5c19f83d1d7b40e9def37a7a6099bbca2 # pin@v0.8.10
 
       - name: unlock on merge
-        uses: github/branch-deploy@fded0351b6b79f854b335c11b3d93063461dd288 # pin@v11
+        uses: github/branch-deploy@f0984057ffe1aa340aa017b6eafb894310aed88e # pin@v12.0.0
         id: unlock-on-merge
         with:
           unlock_on_merge_mode: "true" # <-- indicates that this is the "Unlock on Merge Mode" workflow

--- a/script/ci/test_update_deploy_msg.py
+++ b/script/ci/test_update_deploy_msg.py
@@ -1,40 +1,44 @@
 import sys
 import unittest
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from update_deploy_msg import render_deploy_message
+from update_deploy_msg import write_deploy_message
 
 
-class RenderDeployMessageTest(unittest.TestCase):
-    def test_renders_results_without_consuming_branch_deploy_template(self):
-        template_path = Path(__file__).resolve().parents[2] / '.github' / 'deployment_message.md'
-        rendered = render_deploy_message(
-            template_path.read_text(encoding='utf-8'),
-            'planned changes',
-        )
+class WriteDeployMessageTest(unittest.TestCase):
+    def test_writes_results_without_preprocessing_template_syntax(self):
+        with TemporaryDirectory() as tmpdir:
+            github_env = Path(tmpdir) / 'github-env'
+            write_deploy_message(
+                github_env,
+                '{{ value }}\n{% if changed %}\n{# note #}',
+                delimiter_factory=lambda _length: '0' * 32,
+            )
 
-        self.assertNotIn('{% raw %}', rendered)
-        self.assertNotIn('{% endraw %}', rendered)
-        self.assertNotIn('[[ results ]]', rendered)
-        self.assertIn('planned changes', rendered)
-        self.assertIn('{{ actor }}', rendered)
-        self.assertIn('{{ ref }}', rendered)
-        self.assertIn('{{ environment }}', rendered)
+            self.assertEqual(
+                github_env.read_text(encoding='utf-8'),
+                'DEPLOY_MESSAGE<<branch_deploy_00000000000000000000000000000000\n'
+                '{{ value }}\n{% if changed %}\n{# note #}\n'
+                'branch_deploy_00000000000000000000000000000000\n',
+            )
 
-    def test_escapes_nunjucks_opening_delimiters_in_results(self):
-        rendered = render_deploy_message(
-            '[[ results ]]',
-            '{{ value }}\n{% if changed %}\n{# note #}',
-        )
+    def test_retries_when_delimiter_collides_with_result_line(self):
+        delimiters = iter(['a' * 32, 'b' * 32])
+        with TemporaryDirectory() as tmpdir:
+            github_env = Path(tmpdir) / 'github-env'
+            write_deploy_message(
+                github_env,
+                'branch_deploy_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                delimiter_factory=lambda _length: next(delimiters),
+            )
 
-        self.assertIn('{ { value }}', rendered)
-        self.assertIn('{ % if changed %}', rendered)
-        self.assertIn('{ # note #}', rendered)
-        self.assertNotIn('{{ value }}', rendered)
-        self.assertNotIn('{% if changed %}', rendered)
-        self.assertNotIn('{# note #}', rendered)
+            self.assertIn(
+                'DEPLOY_MESSAGE<<branch_deploy_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+                github_env.read_text(encoding='utf-8'),
+            )
 
 
 if __name__ == '__main__':

--- a/script/ci/update_deploy_msg.py
+++ b/script/ci/update_deploy_msg.py
@@ -1,45 +1,35 @@
 import os
+import secrets
 from pathlib import Path
 
-TEMPLATE_FILE = Path('.github/deployment_message.md')
-RAW_START = '{% raw %}'
-RAW_END = '{% endraw %}'
-RESULTS_PLACEHOLDER = '[[ results ]]'
+DEFAULT_RESULTS = 'No deployment results were captured.'
 
 
-def escape_nunjucks_opening_delimiters(results):
-    escaped = []
-    results = str(results)
+def write_deploy_message(github_env, results, delimiter_factory=secrets.token_hex):
+    results = str(results or DEFAULT_RESULTS)
+    result_lines = set(results.splitlines())
 
-    for index, char in enumerate(results):
-        if char == '{' and index + 1 < len(results) and results[index + 1] in '{%#':
-            escaped.append('{ ')
-        else:
-            escaped.append(char)
+    while True:
+        delimiter = f'branch_deploy_{delimiter_factory(16)}'
+        if delimiter not in result_lines:
+            break
 
-    return ''.join(escaped)
-
-
-def render_deploy_message(template_text, results):
-    return (
-        template_text
-        .replace(RAW_START, '')
-        .replace(RAW_END, '')
-        .replace(RESULTS_PLACEHOLDER, escape_nunjucks_opening_delimiters(results))
-    )
+    with Path(github_env).open('a', encoding='utf-8') as env_file:
+        env_file.write(f'DEPLOY_MESSAGE<<{delimiter}\n')
+        env_file.write(results)
+        if not results.endswith('\n'):
+            env_file.write('\n')
+        env_file.write(f'{delimiter}\n')
 
 
 def main():
-    results = os.environ.get('MSG', False)
-    rendered_template = render_deploy_message(
-        TEMPLATE_FILE.read_text(encoding='utf-8'),
-        results,
-    )
+    results = os.environ.get('MSG', DEFAULT_RESULTS)
+    github_env = os.environ.get('GITHUB_ENV')
 
-    print(rendered_template)
+    if not github_env:
+        raise RuntimeError('GITHUB_ENV is required')
 
-    if os.environ.get('GITHUB_ACTIONS', False):
-        TEMPLATE_FILE.write_text(rendered_template, encoding='utf-8')
+    write_deploy_message(github_env, results)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- pin every Branch Deploy workflow to v12.0.0’s immutable executable commit
- migrate the custom deployment message to v12’s trusted template and single-pass results contract